### PR TITLE
Swap arguments in MaxPoolLayer test cases

### DIFF
--- a/Tests/TestMaxPoolLayer.py
+++ b/Tests/TestMaxPoolLayer.py
@@ -23,25 +23,25 @@ class TestMaxPooling(unittest.TestCase):
         self.layers.append(Helpers.SoftMax())
 
     def test_shape(self):
-        layer = self.MaxPooling((2, 2), (2, 2))
+        layer = self.MaxPooling(neighborhood=(2, 2), stride=(2, 2))
         result = layer.forward(self.input_tensor)
         expected_shape = np.array([self.batch_size, 2, 2, 3])
         self.assertEqual(np.abs(np.sum(np.array(result.shape) - expected_shape)), 0)
 
     def test_overlapping_shape(self):
-        layer = self.MaxPooling((2, 1), (2, 2))
+        layer = self.MaxPooling(neighborhood=(2, 2), stride=(2, 1))
         result = layer.forward(self.input_tensor)
         expected_shape = np.array([self.batch_size, 2, 2, 6])
         self.assertEqual(np.abs(np.sum(np.array(result.shape) - expected_shape)), 0)
 
     def test_subsampling_shape(self):
-        layer = self.MaxPooling((3, 2), (2, 2))
+        layer = self.MaxPooling(neighborhood=(2, 2), stride=(3, 2))
         result = layer.forward(self.input_tensor)
         expected_shape = np.array([self.batch_size, 2, 1, 3])
         self.assertEqual(np.abs(np.sum(np.array(result.shape) - expected_shape)), 0)
 
     def test_gradient_stride(self):
-        self.layers[0] = self.MaxPooling((2, 2), (2, 2))
+        self.layers[0] = self.MaxPooling(neighborhood=(2, 2), stride=(2, 2))
         self.layers[2] = self.FullyConnected(12, self.categories, 0.)
 
         difference = Helpers.gradient_check(self.layers, self.input_tensor, self.label_tensor)
@@ -49,7 +49,7 @@ class TestMaxPooling(unittest.TestCase):
         self.assertLessEqual(np.sum(difference), 1e-6)
 
     def test_gradient_overlapping_stride(self):
-        self.layers[0] = self.MaxPooling((2, 1), (2, 2))
+        self.layers[0] = self.MaxPooling(neighborhood=(2, 2), stride=(2, 1))
         self.layers[2] = self.FullyConnected(24, self.categories, 0.)
 
         difference = Helpers.gradient_check(self.layers, self.input_tensor, self.label_tensor)
@@ -58,7 +58,7 @@ class TestMaxPooling(unittest.TestCase):
 
     def test_gradient_subsampling_stride(self):
 
-        self.layers[0] = self.MaxPooling((3, 2), (2, 2))
+        self.layers[0] = self.MaxPooling(neighborhood=(2, 2), stride=(3, 2))
         self.layers[2] = self.FullyConnected(6, self.categories, 0.)
 
         difference = Helpers.gradient_check(self.layers, self.input_tensor, self.label_tensor)
@@ -66,7 +66,7 @@ class TestMaxPooling(unittest.TestCase):
         self.assertLessEqual(np.sum(difference), 1e-6)
 
     def test_layout_preservation(self):
-        pool = self.MaxPooling((1, 1), (1, 1))
+        pool = self.MaxPooling(neighborhood=(1, 1), stride=(1, 1))
         input_tensor = np.array(range(np.prod(self.input_shape) * self.batch_size), dtype=np.float)
         input_tensor = input_tensor.reshape(self.batch_size, *self.input_shape)
         output_tensor = pool.forward(input_tensor)
@@ -74,7 +74,7 @@ class TestMaxPooling(unittest.TestCase):
 
     def test_expected_output_valid_edgecase(self):
         input_shape = (1, 3, 3)
-        pool = self.MaxPooling((2, 2), (2, 2))
+        pool = self.MaxPooling(neighborhood=(2, 2), stride=(2, 2))
         batch_size = 2
         input_tensor = np.array(range(np.prod(input_shape) * batch_size), dtype=np.float)
         input_tensor = input_tensor.reshape(batch_size, *input_shape)
@@ -85,7 +85,7 @@ class TestMaxPooling(unittest.TestCase):
 
     def test_expected_output(self):
         input_shape = (1, 4, 4)
-        pool = self.MaxPooling((2, 2), (2, 2))
+        pool = self.MaxPooling(neighborhood=(2, 2), stride=(2, 2))
         batch_size = 2
         input_tensor = np.array(range(np.prod(input_shape) * batch_size), dtype=np.float)
         input_tensor = input_tensor.reshape(batch_size, *input_shape)


### PR DESCRIPTION
The MaxPoolLayer test cases appear to pass the stride as first argument and neighborhood as second argument, but its constructor expects the neighborhood as the first argument and the stride as the second argument.

For example, the test case `test_overlapping_shape` uses for the last dimension `neighborhood=1` and `stride=2`. Using the formula from [1], the output width is calculated as `(input_width - neighborhood) / stride + 1 = (7 - 1) // 2 + 1 = 4`, but the test case expects an output width of `6`. The output width would be `6` if the neighborhood and stride arguments were swapped.

[1] https://cs231n.github.io/convolutional-networks/#pool