### PR TITLE
Fix inconsistent use of drop probability and keep probability

### DIFF
--- a/tutorial_dl.ipynb
+++ b/tutorial_dl.ipynb
@@ -260,7 +260,7 @@
     "            param: learning_rate (float): the learning rate of this layer\n",
     "        \"\"\"\n",
     "        # TODO: define the neccesary class variables\n",
-	"        self.weights = ... #\n",
+    "        self.weights = ... #\n",
     "        pass\n",
     "\n",
     "    def forward(self, x):\n",
@@ -989,15 +989,15 @@
     "## Dropout\n",
     "\n",
     "Most successful deep learning models use some regularization techniques intended to decrease the gap between training and test accuracy. The goal is to bias the model towards a model with lower training accuracy but better generalization capability. One prominent technique is dropout. It was for example used in the famous AlexNet network. \n",
-    "The idea of this technique is to break dependencies between features by setting random activations to zero during training. This is typically done with a Bernoulli distribution: In each training iteration, the probability for a certain activation to \"drop out\" is $1-p$.\n",
-    "The application of dropout shifts the mean of the activations because many elements are set to zero during training. At test time, when no element are dropped out, the mean is different, which can decrease performance. To combat this the \"training mean\" can be restored by multiplying all activations with $p$ at test time.\n",
+    "The idea of this technique is to break dependencies between features by setting random activations to zero during training. This is typically done with a Bernoulli distribution: In each training iteration, the probability for a certain activation to \"drop out\" is $p$.\n",
+    "The application of dropout shifts the mean of the activations because many elements are set to zero during training. At test time, when no element are dropped out, the mean is different, which can decrease performance. To combat this the \"training mean\" can be restored by multiplying all activations with $1 - p$ at test time.\n",
     " \n",
     "### Inverted dropout\n",
-    "The multiplication at test time can be avoiding by rewriting dropout behaviour during training. This means that the dropout layer can actually be skipped completely during test time, allowing for faster inference. To this end, the activations are multiplied by $\\frac{1}{p}$ after applying the stochastic function during training. This way, the mean is not changed by the layer and no operation needs to be performed during test time.\n",
+    "The multiplication at test time can be avoiding by rewriting dropout behaviour during training. This means that the dropout layer can actually be skipped completely during test time, allowing for faster inference. To this end, the activations are multiplied by $\\frac{1}{1 - p}$ after applying the stochastic function during training. This way, the mean is not changed by the layer and no operation needs to be performed during test time.\n",
     "\n",
     "\n",
     "### Implementation task\n",
-    "In the following, implement the ```DropOut``` layer. Both \"normal\" and inverted dropout are valid implementations. As usual, check your implementation by running the unittests. Note that dropout operates on each element of the input vector independently."
+    "In the following, implement the ```DropOut``` layer with inverted dropout. As usual, check your implementation by running the unittests. Note that dropout operates on each element of the input vector independently."
    ]
   },
   {
@@ -1013,7 +1013,7 @@
     "    \n",
     "    def __init__(self, probability):\n",
     "        \"\"\" DropOut Layer.\n",
-    "            param: probability: probability of each individual activation to be set to zero, in range [0, 1]    \n",
+    "            param: drop_probability: probability of each individual activation to be set to zero, in range [0, 1]    \n",
     "        \"\"\"\n",
     "        # TODO: Implement initialization\n",
     "        \n",


### PR DESCRIPTION
In the current version, p in the text refers to the keep rate whereas the first argument to the Dropout layer is the drop rate. I suggest to define p as the drop rate, because then the layer signature is consistent with the signature in TensorFlow and PyTorch.

Additionally, a student discovered that the test cases fail for "normal" dropout. The easiest fix is to ask for the inverted dropout implementation.